### PR TITLE
Nfts-meta prototypes

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -29,3 +29,17 @@ export interface TokenInfo {
   description?: string
   logoURI?: string
 }
+
+export interface NftsList {
+  networkId: number
+  nfts: NftInfo[]
+}
+
+export interface NftInfo {
+  id: string
+  name: string
+  description: string
+  uri: string
+  image: string
+  collectionAddress: string
+}

--- a/nfts/mainnet.json
+++ b/nfts/mainnet.json
@@ -1,0 +1,4 @@
+{
+  "networkId": 0,
+  "nfts": []
+}

--- a/nfts/testnet.json
+++ b/nfts/testnet.json
@@ -1,0 +1,21 @@
+{
+  "networkId": 1,
+  "nfts": [
+    {
+      "id": "37ef47e40c2d9a53e0c80999f0f5aec4320f9f57159a2903b53043c7830cb400",
+      "name": "Godfather 1",
+      "description": "Godfather 1",
+      "uri": "https://alephium-nft.infura-ipfs.io/ipfs/QmYePEfp2cZdDyTr4QSiJNgoWrxJfjtcBFAjywm2sptJRJ",
+      "image": "https://alephium-nft.infura-ipfs.io/ipfs/QmSg9JiERPLXKo22C3AD7PgSE7PACuPu9iM1FFCn3AmhNs",
+      "collectionAddress": "22fnZLkZJUSyhXgboirmJktWkEBRk1pV8L6gfpc53hvVM"
+    },
+    {
+      "id": "eb7746d12397c87599abf3d487265679660c2754a527443539fd7b291d316000",
+      "name": "Godfather 3",
+      "description": "Godfather 3",
+      "uri": "https://alephium-nft.infura-ipfs.io/ipfs/QmXnHbavrFSWxsb2pnM2b1XmE3ifkwy77XgEroeFQCu7Q4",
+      "image": "https://alephium-nft.infura-ipfs.io/ipfs/QmSg9JiERPLXKo22C3AD7PgSE7PACuPu9iM1FFCn3AmhNs",
+      "collectionAddress": "22fnZLkZJUSyhXgboirmJktWkEBRk1pV8L6gfpc53hvVM"
+    }
+  ]
+}


### PR DESCRIPTION
We could create a repo on its own for the nfts, but we could start here to simplify everything.

We had few back and forth with Hongchao about this. The ideal solution would be to automatically extract those information from the node, from the explorer. Unfortunately when we query the state of a contract, we get the bytecodes and the fields. From the fields we can find the various info added in the json here, but we can't assert if the contract is an NFT or not, for this we need the source code of the contract and check if it respect the standard (TBD), from the bytecode we don't have enough information.
As found by Hongchao, there is this [EIP](https://eips.ethereum.org/EIPS/eip-165) that could go in our direction, but currently it's not possible. 

The simplest version to begin is the json file, the same way we have for the tokens. If someone want his NFT to appear in the explorer/wallet, he can add them here.

Another option to dig is the [metamask](https://metamask.zendesk.com/hc/en-us/articles/360058238591-NFT-tokens-in-your-MetaMask-wallet) one, if someone want his NFT and his wallet, he can add them locally just for him.

We could also have both way, as one is global, the other local.

Regarding the format, I'm not sure we need all fields, as `name`, `description` and `image` can be found at the `uri` page, but it would mean when the front-end want to show the image, it will first need to query the `uri` in order to get all other info. 
We could also remove `uri`, but ask for it when people submit a PR, so we can check the validity of the entry.

As for the tokens, we'll need to come with a standard at some point, like the [ERC-721](https://eips.ethereum.org/EIPS/eip-721)

For the two NFTs I added here, they are truely the 2 NFTs present in our testnet. To find the info I had to:
* Convert `tokenId` to an `address` (easily done with the SDK or in scala)
* Call the `/contracts/{address}/state` endpoint
* Extract the info from the `fields`. `ByteVec` are easily convertible using for example [that website](https://onlinestringtools.com/convert-bytes-to-string) or using [xxd](https://www.tutorialspoint.com/unix_commands/xxd.htm)
```
 echo  "68747470733a2f2f616c65706869756d2d6e66742e696e667572612d697066732e696f2f697066732f516d59655045667032635a6444795472345153694a4e676f5772784a666a74634246416a79776d327370744a524a" | xxd -r -p

https://alephium-nft.infura-ipfs.io/ipfs/QmYePEfp2cZdDyTr4QSiJNgoWrxJfjtcBFAjywm2sptJRJ
```

You can check those tokens' txs [here](https://backend-v112.testnet.alephium.org/tokens/37ef47e40c2d9a53e0c80999f0f5aec4320f9f57159a2903b53043c7830cb400/transactions) and [here](https://backend-v112.testnet.alephium.org/tokens/eb7746d12397c87599abf3d487265679660c2754a527443539fd7b291d316000/transactions) 

and also the contract state [here](https://wallet-v16.testnet.alephium.org/contracts/xTJA5EXW8GRoCDVVyWTpeX9ikTofG1RaceZzoRJdX9Us/state?group=0) and [here](https://wallet-v16.testnet.alephium.org/contracts/2AY7QmGGHAMCxyXuLkkbvDFcMn7gQasxwaErPAU4Vdjew/state?group=0)