### PR TITLE
Introduce nfts with current testnet default market place

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -29,3 +29,12 @@ export interface TokenInfo {
   description?: string
   logoURI?: string
 }
+
+export interface NftsList {
+  networkId: number
+  collections: CollectionInfo[]
+}
+
+export interface CollectionInfo {
+  id: string
+}

--- a/nfts/mainnet.json
+++ b/nfts/mainnet.json
@@ -1,0 +1,4 @@
+{
+  "networkId": 0,
+  "nfts": []
+}

--- a/nfts/testnet.json
+++ b/nfts/testnet.json
@@ -1,0 +1,8 @@
+{
+  "networkId": 1,
+  "collections": [
+    {
+      "id": "28AL78tSb7apkhrmHSoxwt26i7jRD3uBDkbTqHtEmhnpf"
+    }
+  ]
+}


### PR DESCRIPTION
As explain [here](https://github.com/alephium/token-list/pull/4#issuecomment-1418693207)

Contract state of the address added in this PR can be found [here](https://wallet-v17.testnet.alephium.org/contracts/28AL78tSb7apkhrmHSoxwt26i7jRD3uBDkbTqHtEmhnpf/state?group=0)

The immFields correspond to [this contract](https://github.com/alephium/alephium-nft/blob/7d555fc17679564784bfd261e867a11793040fcf/contracts/nft_collection.ral#L3-L8)

If you convert fields 1-3 you'll get:
* DefaultCollection
* Default Collection
* http://default.collection

the first field being the `nftTemplateId`, address `222drNnyBQGEpt3p2htVy1qSnUhtFG5Xhc432wawC7XrF`

In [this explorer-backend PR](https://github.com/alephium/explorer-backend/pull/434) We will store when this collection contract is minting some NFTs. We can see the table on our current testnet (data from my local machine as the PR isn't deployed):
```
testnet171=# select contract, sub_contract from create_sub_contract_events ;
                   contract                    |                 sub_contract
-----------------------------------------------+-----------------------------------------------
 21ZpFLBGSiy8GrxuoXgXA1zXLRA2uMRMSfC5t4M2j7SND | 2BjLJX3Eeo9SwHWf4Nzgf9xqmZVAJuCXGf64G2qF9oiFb
 28AL78tSb7apkhrmHSoxwt26i7jRD3uBDkbTqHtEmhnpf | 2BVNVDEjRMVzPEqcPGnoJVpv9uScFz7J8LKXPSXxnLVq9
 28AL78tSb7apkhrmHSoxwt26i7jRD3uBDkbTqHtEmhnpf | 21KXY6RPfGKZCYxgwrQ1LdrZkBTwsg7yYHiDY6fDoda71
 2B84kHh3USAzrBvd88eKKYUshfR25Pp8rXwvieHWshjEf | 28Bs9BigF5eEFBW5poHDsUUPMEmtmZthH4FvDxyS2hGsZ
 2B84kHh3USAzrBvd88eKKYUshfR25Pp8rXwvieHWshjEf | 25e7HtK3kfZRBWxrkkvwYxGJ8MTx2z1sRzqEsBDjc88Lo
(5 rows)
```

We have two sub-contracts for `28AL78tSb7apkhrmHSoxwt26i7jRD3uBDkbTqHtEmhnpf`, we can get their state:
*  https://wallet-v17.testnet.alephium.org/contracts/2BVNVDEjRMVzPEqcPGnoJVpv9uScFz7J8LKXPSXxnLVq9/state?group=0
*  https://wallet-v17.testnet.alephium.org/contracts/21KXY6RPfGKZCYxgwrQ1LdrZkBTwsg7yYHiDY6fDoda71/state?group=0

Those are the states of [this contract](https://github.com/alephium/alephium-nft/blob/7d555fc17679564784bfd261e867a11793040fcf/contracts/nft.ral#L4-L11) and the long `ByteVec` is the `uri`. If you convert them you get:

* https://alephium-nft.infura-ipfs.io/ipfs/QmRJ1zC2RgEYwjf3kHtjpWsguk1weHh5a9niWjMdjnjnnz
* https://alephium-nft.infura-ipfs.io/ipfs/QmUvVBybRbknq4KDFWuMXPcXaoVggsJ6STybBx5SUaYvNJ

Where you can get the uri for the two nft's image.