### PR TITLE
Fix async tests

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -24,7 +24,9 @@ export interface TokenList {
 export interface TokenInfo {
   id: string
   name: string
+  onChainName?: string
   symbol: string
+  onChainSymbol?: string
   decimals: number
   description?: string
   logoURI?: string

--- a/test/nft-collection-list/nft-collection-list.test.ts
+++ b/test/nft-collection-list/nft-collection-list.test.ts
@@ -85,12 +85,12 @@ describe('NFTCollectionList', function () {
   }
 
   async function validateNftCollectionUriData(metadata: NFTCollectionMetaData) {
-    fetch(metadata.collectionUri)
+    await fetch(metadata.collectionUri)
       .then((result) => result.json())
       .then((json) => validateNftMetadata(json as NFTMetadata))
   }
 
   async function validateNftMetadata(nftMetadata: NFTMetadata) {
-    fetch(nftMetadata.image).then((image) => expect(image.headers.get('content-type')).toContain('image/'))
+    await fetch(nftMetadata.image).then((image) => expect(image.headers.get('content-type')).toContain('image/'))
   }
 })

--- a/test/token-list/token-list.test.ts
+++ b/test/token-list/token-list.test.ts
@@ -87,11 +87,11 @@ describe('TokenList', function () {
   })
 
   async function validateTokenType(token: TokenInfo, nodeProvider: NodeProvider) {
-    nodeProvider.guessStdTokenType(token.id).then((tokenType) => expect(tokenType).toEqual('fungible'))
+    await nodeProvider.guessStdTokenType(token.id).then((tokenType) => expect(tokenType).toEqual('fungible'))
   }
 
   async function validateTokenMetadata(token: TokenInfo, nodeProvider: NodeProvider) {
-    nodeProvider.fetchFungibleTokenMetaData(token.id).then((metadata) => checkMetadata(metadata, token))
+    await nodeProvider.fetchFungibleTokenMetaData(token.id).then((metadata) => checkMetadata(metadata, token))
   }
 
   function checkMetadata(metadata: FungibleTokenMetaData, token: TokenInfo) {

--- a/test/token-list/token-list.test.ts
+++ b/test/token-list/token-list.test.ts
@@ -95,8 +95,8 @@ describe('TokenList', function () {
   }
 
   function checkMetadata(metadata: FungibleTokenMetaData, token: TokenInfo) {
-    expect(hexToString(metadata.name)).toEqual(token.name)
-    expect(hexToString(metadata.symbol)).toEqual(token.symbol)
+    expect(hexToString(metadata.name)).toEqual(token.onChainName ? token.onChainName : token.name)
+    expect(hexToString(metadata.symbol)).toEqual(token.onChainSymbol ? token.onChainSymbol : token.symbol)
     expect(metadata.decimals).toEqual(token.decimals)
   }
 })


### PR DESCRIPTION
* Allow tokens with same name and symbol

As it's allowed on-chain, we have to allow them, we thus only check
duplicates of ids

* Fix async testing

We were missing some `async` and some results were run in background and
not reported to jest correctly.

* Move logos to their id name

Now that we allow tokens with same symbols, we need to change their name
to be the id, to avoid future clash
