### PR TITLE
Add originChain Property

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -28,6 +28,7 @@ export interface TokenInfo {
   decimals: number
   description: string
   logoURI: string
+  originChain?: string
 }
 
 export type NetworkId = 'mainnet' | 'testnet'

--- a/test/token-list/token-list.test.ts
+++ b/test/token-list/token-list.test.ts
@@ -81,7 +81,17 @@ describe('TokenList', function () {
   })
 
   it('should not contain extra fields', () => {
-    const allowedFields = ['id', 'name', 'nameOnChain', 'symbol', 'symbolOnChain', 'decimals', 'description', 'logoURI']
+    const allowedFields = [
+      'id',
+      'name',
+      'nameOnChain',
+      'symbol',
+      'symbolOnChain',
+      'decimals',
+      'description',
+      'logoURI',
+      'originChain'
+    ]
     tokenLists.forEach((tokenList) => {
       tokenList.tokens.forEach((token) => {
         const tokenFields = Object.keys(token)
@@ -135,6 +145,7 @@ describe('TokenList', function () {
   }
 
   const tokensWithSymbolVariant = ['ALF', 'ANS', 'USDT', 'USDC']
+  const originChains = ['BSC', 'Ethereum']
 
   function checkMetadata(metadata: FungibleTokenMetaData, token: TokenInfoJson) {
     expect(hexToString(metadata.name)).toEqual(token.nameOnChain ?? token.name)
@@ -143,6 +154,10 @@ describe('TokenList', function () {
 
     if (token.symbolOnChain !== undefined) {
       expect(tokensWithSymbolVariant.includes(token.symbolOnChain)).toBe(true)
+    }
+
+    if (token.originChain !== undefined) {
+      expect(originChains.includes(token.originChain)).toBe(true)
     }
   }
 })

--- a/tokens/mainnet.json
+++ b/tokens/mainnet.json
@@ -101,43 +101,47 @@
     },
     {
       "id": "556d9582463fe44fbd108aedc9f409f69086dc78d994b88ea6c9e65f8bf98e00",
-      "name": "Tether USD (AlphBridge from Ethereum)",
+      "name": "Tether USD (Ethereum via AlphBridge)",
       "nameOnChain": "Tether USD (AlphBridge)",
       "symbol": "USDTet",
       "symbolOnChain": "USDT",
       "decimals": 6,
       "description": "USDT Bridged to Alephium from Ethereum via Alephium Bridge",
-      "logoURI": "https://raw.githubusercontent.com/alephium/token-list/master/logos/USDTet.png"
+      "logoURI": "https://raw.githubusercontent.com/alephium/token-list/master/logos/USDTet.png",
+      "originChain": "Ethereum"
     },
     {
       "id": "7ff5e72636f640eb2c28056df3b6879e4c86933505abebf566518ad396335700",
-      "name": "Tether USD (AlphBridge from BSC)",
+      "name": "Tether USD (BSC via AlphBridge)",
       "nameOnChain": "Tether USD (AlphBridge)",
       "symbol": "USDTbs",
       "symbolOnChain": "USDT",
       "decimals": 18,
       "description": "USDT Bridged to Alephium from BSC via Alephium Bridge",
-      "logoURI": "https://raw.githubusercontent.com/alephium/token-list/master/logos/USDTbs.png"
+      "logoURI": "https://raw.githubusercontent.com/alephium/token-list/master/logos/USDTbs.png",
+      "originChain": "BSC"
     },
     {
       "id": "722954d9067c5a5ad532746a024f2a9d7a18ed9b90e27d0a3a504962160b5600",
-      "name": "USD Coin (AlphBridge from Ethereum)",
+      "name": "USD Coin (Ethereum via AlphBridge)",
       "nameOnChain": "USD Coin (AlphBridge)",
       "symbol": "USDCet",
       "symbolOnChain": "USDC",
       "decimals": 6,
       "description": "USDC Bridged to Alephium from Ethereum via Alephium Bridge",
-      "logoURI": "https://raw.githubusercontent.com/alephium/token-list/master/logos/USDCet.png"
+      "logoURI": "https://raw.githubusercontent.com/alephium/token-list/master/logos/USDCet.png",
+      "originChain": "Ethereum"
     },
     {
       "id": "75e1e9f91468616a371fe416430819bf5386a3e6a258864c574271a404ec8900",
-      "name": "USD Coin (AlphBridge from BSC)",
+      "name": "USD Coin (BSC via AlphBridge)",
       "nameOnChain": "USD Coin (AlphBridge)",
       "symbol": "USDCbs",
       "symbolOnChain": "USDC",
       "decimals": 18,
       "description": "USDC Bridged to Alephium from BSC via Alephium Bridge",
-      "logoURI": "https://raw.githubusercontent.com/alephium/token-list/master/logos/USDCbs.png"
+      "logoURI": "https://raw.githubusercontent.com/alephium/token-list/master/logos/USDCbs.png",
+      "originChain": "BSC"
     },
     {
       "id": "3d0a1895108782acfa875c2829b0bf76cb586d95ffa4ea9855982667cc73b700",


### PR DESCRIPTION
- Add `originChain` property for wallet to display token better (potentially overlay the logo of the origin chain)
- Update `USDT` & `USDC` token names so that wallet can display them better