### PR TITLE
Update wSMT token ID (Group 0 redeploy for DEX compatibility)

### DIFF
--- a/tokens/mainnet.json
+++ b/tokens/mainnet.json
@@ -1841,7 +1841,7 @@
       "logoURI": "https://raw.githubusercontent.com/alephium/token-list/master/logos/MAUD.png"
     },
     {
-      "id": "c883cbc1560517b8ddc25fa857c27db39402f3aece0cd1a7a0923485ddc7f403",
+      "id": "10d9a89352d75281e8d2c0d5dc46938960f1070a7d00fe94ec158f5a1b971c00",
       "name": "Wrapped Smartiecoin",
       "symbol": "wSMT",
       "decimals": 8,


### PR DESCRIPTION
## Summary

Updates the wSMT (Wrapped Smartiecoin) token ID to the new Group 0 contract
deployment. Name, symbol, decimals, description, and logo are unchanged.

## Reason for change

The previous wSMT contract was deployed on Alephium Group 3. Several Alephium
DEXes (e.g. Elexium Finance) only support Group 0 tokens for liquidity pair
creation. We redeployed the contract to Group 0 so wSMT can be traded on-chain
against ALPH and other G0 assets.

## New contract details

- Token ID: `10d9a89352d75281e8d2c0d5dc46938960f1070a7d00fe94ec158f5a1b971c00`
- Contract address: `upj8jW5YBt8PEBLYBEzkNgvUjqmGNYxDdC6VqmHzP3pK`
- Bridge contract: `27iSE3oiwwh7p24eMzdMrZywbwcMqEemS5WXjStPTbeym`
- Group: 0
- Owner: Ledger-held
- Standard interface: `@std(id = #0001)` (fungible token)

## Verification

- `guessStdTokenType` returns `"fungible"` ✓
- Symbol/name match on-chain state ✓
- Decimals: 8 (matches native SMT) ✓
- Logo unchanged (reusing existing `logos/wSMT.png`)
- End-to-end bridge mint and burn verified on new contract

## Previous token status

The old Group 3 wSMT contract has been paused on its bridge. All outstanding
G3 wSMT (499 tokens) was internal testing only; no external users held G3 wSMT.

## Bridge site

https://smartiecoinalephiumbridge.enchantedforestdefi.com