### PR TITLE
Add dUSD Stable testnet token

### DIFF
--- a/tokens/testnet.json
+++ b/tokens/testnet.json
@@ -352,6 +352,13 @@
       "decimals": 18,
       "description": "cexy.ai (test)",
       "logoURI": "https://raw.githubusercontent.com/alephium/token-list/master/logos/CEXY.png"
+    },
+    {
+      "id": "bb36233e411b32539210d59e526c7f925881a5b7d3f8dc42386e32ab281e3800",
+      "name": "dUSD Stable",
+      "symbol": "dUSD",
+      "decimals": 18,
+      "description": "DOH-backed USD stablecoin on Alephium testnet"
     }
   ]
 }

--- a/tokens/testnet.json
+++ b/tokens/testnet.json
@@ -354,7 +354,7 @@
       "logoURI": "https://raw.githubusercontent.com/alephium/token-list/master/logos/CEXY.png"
     },
     {
-      "id": "bb36233e411b32539210d59e526c7f925881a5b7d3f8dc42386e32ab281e3800",
+      "id": "fe075bce6a874e26d05f9160e3667175451a7d18fe268e1be9536ca1d8ceb600",
       "name": "dUSD Stable",
       "symbol": "dUSD",
       "decimals": 18,


### PR DESCRIPTION
## Token Details

- **Token Name**: dUSD Stable
- **Symbol**: dUSD
- **Network**: Testnet
- **Contract ID**: `fe075bce6a874e26d05f9160e3667175451a7d18fe268e1be9536ca1d8ceb600`
- **Decimals**: 18
- **Standard**: IFungibleToken (@std id = #0001)

## Description
DOH-backed USD stablecoin on Alephium testnet. Fully implements the IFungibleToken interface with proper `__stdInterfaceId` format (`414c50480001` = "ALPH" prefix + interface ID).

## Compliance Checklist
- ✅ `getName()` returns "dUSD Stable"
- ✅ `getSymbol()` returns "dUSD"
- ✅ `getDecimals()` returns 18
- ✅ `getTotalSupply()` implemented
- ✅ `guessStdTokenType()` returns "fungible" ✅

## Verification
```javascript
const {NodeProvider} = require('@alephium/web3');
const node = new NodeProvider('https://node.testnet.alephium.org');
await node.guessStdTokenType('fe075bce6a874e26d05f9160e3667175451a7d18fe268e1be9536ca1d8ceb600');
// Returns: 'fungible' ✅
```

## Contract Source
https://github.com/dohmoney/Decentralized_Open_Hub/blob/main/contracts/DUSD.ral